### PR TITLE
Ensuring output directory creation if not already present using makefile

### DIFF
--- a/data/cpp/deadlock/src/Makefile
+++ b/data/cpp/deadlock/src/Makefile
@@ -14,6 +14,7 @@ $(OBJ): $(SRC)
 	$(CXX) $(CXXFLAGS) -c $(SRC) $(INC) -o $(OBJ)
 
 $(TARGET): $(OBJ)
+	mkdir -p ../output
 	$(AR) rcs $(TARGET) $(OBJ)
 
 clean:

--- a/data/cpp/simplecrash/Makefile
+++ b/data/cpp/simplecrash/Makefile
@@ -2,13 +2,14 @@
 
 CXX = g++
 CXXFLAGS = -Wall -Wextra -std=c++17 -g
-TARGET = main
+TARGET = ./output/test
 SRC = main.cpp
 
 all: $(TARGET)
 
 $(TARGET): $(SRC)
+	mkdir -p ./output
 	$(CXX) $(CXXFLAGS) -o $(TARGET) $(SRC)
 
 clean:
-	rm -f $(TARGET)
+	rm -f ./output/test

--- a/scripts/config_cpp.yaml
+++ b/scripts/config_cpp.yaml
@@ -2,7 +2,7 @@ base:
     # Environment configs
     output_path: "exps/debug_cpp"
     env_kwargs: {
-        "path": "data/cpp/deadlock",
+        "path": "data/cpp/simplecrash",
         "entrypoint": "make && ./output/test",
         "debug_entrypoint": "make && gdb ./output/test",
         "dir_tree_depth": 1,
@@ -27,7 +27,7 @@ base:
 
     # Agent configs
     random_seed: 42
-    max_steps: 50
+    max_steps: 12
     max_rewrite_steps: 10
     memory_size: 20
     save_patch: True


### PR DESCRIPTION
Added mkdir for output directory to ensure make does not complain about missing binaries.


also added code to make TARGET as test directory, instead of main to keep it in sync with other tests configurations. 